### PR TITLE
make floor match mujoco scenes

### DIFF
--- a/urdf2mjcf/postprocess/add_floor.py
+++ b/urdf2mjcf/postprocess/add_floor.py
@@ -83,7 +83,7 @@ def add_floor_assets(root: ET.Element) -> None:
         asset = ET.SubElement(root, "asset")
 
     # Add texture for groundplane
-    texture = ET.SubElement(
+    _ = ET.SubElement(
         asset,
         "texture",
         attrib={
@@ -100,7 +100,7 @@ def add_floor_assets(root: ET.Element) -> None:
     )
 
     # Add material for groundplane
-    material = ET.SubElement(
+    _ = ET.SubElement(
         asset,
         "material",
         attrib={

--- a/urdf2mjcf/postprocess/add_floor.py
+++ b/urdf2mjcf/postprocess/add_floor.py
@@ -37,6 +37,7 @@ def add_floor_default(root: ET.Element, floor_name: str = "floor") -> None:
             "type": "plane",
             "size": "0 0 0.05",  # Match the size from the snippet
             "material": "groundplane",  # Use the groundplane material
+            "rgba": "1 1 1 0.3",
         }
 
         ET.SubElement(floor_default, "geom", attrib=geom_attrib)
@@ -70,6 +71,7 @@ def add_floor_geom(root: ET.Element, floor_name: str = "floor") -> None:
     floor_geom.attrib["contype"] = "1"
     floor_geom.attrib["conaffinity"] = "1"
     floor_geom.attrib["material"] = "groundplane"
+    floor_geom.attrib["rgba"] = "1 1 1 0.3"
 
     # Add the floor geom to the worldbody
     worldbody.append(floor_geom)
@@ -105,7 +107,8 @@ def add_floor_assets(root: ET.Element) -> None:
         "texture": "groundplane",
         "texuniform": "true",
         "texrepeat": "5 5",
-        "reflectance": "0.2"
+        "reflectance": "0.2",
+        "rgba": "1 1 1 0.3"
     })
 
 

--- a/urdf2mjcf/postprocess/add_floor.py
+++ b/urdf2mjcf/postprocess/add_floor.py
@@ -34,11 +34,11 @@ def add_floor_default(root: ET.Element, floor_name: str = "floor") -> None:
         geom_attrib = {
             "contype": "1",  # Enable collision
             "conaffinity": "1",  # Enable collision with all objects
-            "group": "0", # Default value for group
+            "group": "0",  # Default value for group
             "type": "plane",
             "size": "0 0 0.05",
             "material": "groundplane",
-            "rgba": "1 1 1 0.3" # Make transparent
+            "rgba": "1 1 1 0.3",  # Make transparent
         }
 
         ET.SubElement(floor_default, "geom", attrib=geom_attrib)
@@ -81,28 +81,36 @@ def add_floor_assets(root: ET.Element) -> None:
     asset = root.find("asset")
     if asset is None:
         asset = ET.SubElement(root, "asset")
-    
+
     # Add texture for groundplane
-    texture = ET.SubElement(asset, "texture", attrib={
-        "type": "2d",
-        "name": "groundplane",
-        "builtin": "checker",
-        "mark": "edge",
-        "rgb1": "0.2 0.3 0.4",
-        "rgb2": "0.1 0.2 0.3",
-        "markrgb": "0.8 0.8 0.8",
-        "width": "300",
-        "height": "300"
-    })
-    
+    texture = ET.SubElement(
+        asset,
+        "texture",
+        attrib={
+            "type": "2d",
+            "name": "groundplane",
+            "builtin": "checker",
+            "mark": "edge",
+            "rgb1": "0.2 0.3 0.4",
+            "rgb2": "0.1 0.2 0.3",
+            "markrgb": "0.8 0.8 0.8",
+            "width": "300",
+            "height": "300",
+        },
+    )
+
     # Add material for groundplane
-    material = ET.SubElement(asset, "material", attrib={
-        "name": "groundplane",
-        "texture": "groundplane",
-        "texuniform": "true",
-        "texrepeat": "5 5",
-        "reflectance": "0.2"
-    })
+    material = ET.SubElement(
+        asset,
+        "material",
+        attrib={
+            "name": "groundplane",
+            "texture": "groundplane",
+            "texuniform": "true",
+            "texrepeat": "5 5",
+            "reflectance": "0.2",
+        },
+    )
 
 
 def add_floor(mjcf_path: str | Path, floor_name: str = "floor") -> None:

--- a/urdf2mjcf/postprocess/add_floor.py
+++ b/urdf2mjcf/postprocess/add_floor.py
@@ -34,13 +34,10 @@ def add_floor_default(root: ET.Element, floor_name: str = "floor") -> None:
         geom_attrib = {
             "contype": "1",  # Enable collision
             "conaffinity": "1",  # Enable collision with all objects
-            "group": "1",  # Group 1 for floor
-            "friction": "0.8 0.02 0.01",  # Default friction values
-            "condim": "6",  # Default contact dimension
+            "type": "plane",
+            "size": "0 0 0.05",  # Match the size from the snippet
+            "material": "groundplane",  # Use the groundplane material
         }
-
-        geom_attrib["type"] = "plane"
-        geom_attrib["size"] = "100 100 0.1"  # Large plane with small thickness
 
         ET.SubElement(floor_default, "geom", attrib=geom_attrib)
 
@@ -68,11 +65,48 @@ def add_floor_geom(root: ET.Element, floor_name: str = "floor") -> None:
     floor_geom = ET.Element("geom")
     floor_geom.attrib["name"] = floor_name
     floor_geom.attrib["class"] = floor_name
-    floor_geom.attrib["pos"] = "0 0 0"  # Position at origin
-    floor_geom.attrib["quat"] = "1 0 0 0"  # Identity quaternion (no rotation)
+    floor_geom.attrib["size"] = "0 0 0.05"
+    floor_geom.attrib["type"] = "plane"
+    floor_geom.attrib["contype"] = "1"
+    floor_geom.attrib["conaffinity"] = "1"
+    floor_geom.attrib["material"] = "groundplane"
 
     # Add the floor geom to the worldbody
     worldbody.append(floor_geom)
+
+
+def add_floor_assets(root: ET.Element) -> None:
+    """Add the needed assets for the floor.
+
+    Args:
+        root: The root element of the MJCF file.
+    """
+    # Find or create asset element
+    asset = root.find("asset")
+    if asset is None:
+        asset = ET.SubElement(root, "asset")
+    
+    # Add texture for groundplane
+    texture = ET.SubElement(asset, "texture", attrib={
+        "type": "2d",
+        "name": "groundplane",
+        "builtin": "checker",
+        "mark": "edge",
+        "rgb1": "0.2 0.3 0.4",
+        "rgb2": "0.1 0.2 0.3",
+        "markrgb": "0.8 0.8 0.8",
+        "width": "300",
+        "height": "300"
+    })
+    
+    # Add material for groundplane
+    material = ET.SubElement(asset, "material", attrib={
+        "name": "groundplane",
+        "texture": "groundplane",
+        "texuniform": "true",
+        "texrepeat": "5 5",
+        "reflectance": "0.2"
+    })
 
 
 def add_floor(mjcf_path: str | Path, floor_name: str = "floor") -> None:
@@ -84,6 +118,7 @@ def add_floor(mjcf_path: str | Path, floor_name: str = "floor") -> None:
     """
     tree = ET.parse(mjcf_path)
     root = tree.getroot()
+    add_floor_assets(root)
     add_floor_default(root, floor_name)
     add_floor_geom(root, floor_name)
     save_xml(mjcf_path, tree)

--- a/urdf2mjcf/postprocess/add_floor.py
+++ b/urdf2mjcf/postprocess/add_floor.py
@@ -34,10 +34,11 @@ def add_floor_default(root: ET.Element, floor_name: str = "floor") -> None:
         geom_attrib = {
             "contype": "1",  # Enable collision
             "conaffinity": "1",  # Enable collision with all objects
+            "group": "0", # Default value for group
             "type": "plane",
-            "size": "0 0 0.05",  # Match the size from the snippet
-            "material": "groundplane",  # Use the groundplane material
-            "rgba": "1 1 1 0.3",
+            "size": "0 0 0.05",
+            "material": "groundplane",
+            "rgba": "1 1 1 0.3" # Make transparent
         }
 
         ET.SubElement(floor_default, "geom", attrib=geom_attrib)
@@ -67,13 +68,6 @@ def add_floor_geom(root: ET.Element, floor_name: str = "floor") -> None:
     floor_geom.attrib["name"] = floor_name
     floor_geom.attrib["class"] = floor_name
     floor_geom.attrib["size"] = "0 0 0.05"
-    floor_geom.attrib["type"] = "plane"
-    floor_geom.attrib["contype"] = "1"
-    floor_geom.attrib["conaffinity"] = "1"
-    floor_geom.attrib["material"] = "groundplane"
-    floor_geom.attrib["rgba"] = "1 1 1 0.3"
-
-    # Add the floor geom to the worldbody
     worldbody.append(floor_geom)
 
 
@@ -107,8 +101,7 @@ def add_floor_assets(root: ET.Element) -> None:
         "texture": "groundplane",
         "texuniform": "true",
         "texrepeat": "5 5",
-        "reflectance": "0.2",
-        "rgba": "1 1 1 0.3"
+        "reflectance": "0.2"
     })
 
 


### PR DESCRIPTION
This PR makes `add_floor.py` match the mujoco-scenes floor 

Also see https://github.com/kscalelabs/mujoco-scenes/pull/9

Floor before:
![image](https://github.com/user-attachments/assets/8ab9d20c-99c7-4561-a361-6b5d0097fb13)
![image](https://github.com/user-attachments/assets/607afd7a-61b4-40cf-a838-993f1c051c69)
Floor after:
![image](https://github.com/user-attachments/assets/c557e74f-e06f-4e6f-a431-b7de8d7d0e52)
![image](https://github.com/user-attachments/assets/fd743b49-fddd-4031-af06-a4da3ea82ebb)


Before transparency:
![image](https://github.com/user-attachments/assets/cb40a77f-1828-4b9b-b739-29f20e6f2d83)
After transparency:
![image](https://github.com/user-attachments/assets/29edbe5f-b77d-4543-82ed-9ce1eee03022)
