### PR TITLE
Fix origin visual

### DIFF
--- a/urdf2mjcf/convert.py
+++ b/urdf2mjcf/convert.py
@@ -720,14 +720,8 @@ def convert_urdf_to_mjcf(
         # Process visual geometries.
         visuals = link.findall("visual")
         for idx, visual in enumerate(visuals):
-            origin_visual = visual.find("origin")
-            if origin_visual is not None:
-                pos_geom = origin_visual.attrib.get("xyz", "0 0 0")
-                rpy_geom = origin_visual.attrib.get("rpy", "0 0 0")
-                quat_geom = rpy_to_quat(rpy_geom)
-            else:
-                pos_geom = "0 0 0"
-                quat_geom = "1 0 0 0"
+            pos_geom = "0 0 0"
+            quat_geom = "1 0 0 0"
             name = f"{link_name}_visual"
             if len(visuals) > 1:
                 name = f"{name}_{idx}"

--- a/urdf2mjcf/postprocess/collisions.py
+++ b/urdf2mjcf/postprocess/collisions.py
@@ -225,7 +225,7 @@ def update_collisions(
                     capsule_geom.attrib["type"] = "capsule"
                     capsule_geom.attrib["quat"] = " ".join(f"{v:.6f}" for v in sphere_quat)
                     capsule_geom.attrib["fromto"] = " ".join(f"{v:.6f}" for v in capsule_fromto)
-                    capsule_geom.attrib["size"] = f"{rad:.6f} {length/2:.6f}"
+                    capsule_geom.attrib["size"] = f"{rad:.6f} {length / 2:.6f}"
                     capsule_geom.attrib["material"] = "collision_material"
 
                     # Copy over any other attributes from the original mesh geom
@@ -242,7 +242,7 @@ def update_collisions(
                         visual_capsule.attrib["type"] = "capsule"
                         visual_capsule.attrib["quat"] = " ".join(f"{v:.6f}" for v in sphere_quat)
                         visual_capsule.attrib["fromto"] = " ".join(f"{v:.6f}" for v in capsule_fromto)
-                        visual_capsule.attrib["size"] = f"{rad:.6f} {length/2:.6f}"
+                        visual_capsule.attrib["size"] = f"{rad:.6f} {length / 2:.6f}"
 
                         # Copy over material and class attributes
                         for key in ("material", "class"):


### PR DESCRIPTION
Update to the `onshape` package assigns a z position to the origin that gets used for the visual geom. 

<img width="261" alt="image" src="https://github.com/user-attachments/assets/d848804e-32a9-4142-a70e-c163467cac10" />