### PR TITLE
Add geom priority

### DIFF
--- a/urdf2mjcf/convert.py
+++ b/urdf2mjcf/convert.py
@@ -291,6 +291,7 @@ def add_default(
             "condim": str(metadata.collision_params.condim),
             "contype": str(metadata.collision_params.contype),
             "conaffinity": str(metadata.collision_params.conaffinity),
+            "priority": str(metadata.collision_params.priority),
             "group": "1",
             "solref": " ".join(f"{x:.6g}" for x in metadata.collision_params.solref),
             "friction": " ".join(f"{x:.6g}" for x in metadata.collision_params.friction),

--- a/urdf2mjcf/model.py
+++ b/urdf2mjcf/model.py
@@ -12,6 +12,7 @@ class CollisionParams(BaseModel):
     condim: int = 3
     contype: int = 0
     conaffinity: int = 1
+    priority: int = 1
     solimp: list[float] = [0.99, 0.999, 0.00001]
     solref: list[float] = [0.005, 1.0]
     friction: list[float] = [1.0, 0.01, 0.01]


### PR DESCRIPTION
Geom priority is used for determining which geom to pull friction params from in collisions